### PR TITLE
Add image view uploads to shape_generation_api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ venv.bak/
 
 # Environment variables
 .env
+
+sessions/

--- a/hunyuan_service.py
+++ b/hunyuan_service.py
@@ -15,7 +15,10 @@ def get_hunyuan_client():
 
     if _hunyuan_client is None:
         try:
-            _hunyuan_client = Client(hunyuan_space_id)
+            if hunyuan_space_id is not None:
+                _hunyuan_client = Client(hunyuan_space_id)
+            else:
+                raise ValueError("hunyuan_space_id must not be None")
         except Exception as e:
             _hunyuan_client = None
             raise RuntimeError(f"Failed to init Gradio Client: {e}") from e
@@ -33,22 +36,39 @@ def save_generated_model(session_id, model_data, filename):
     model_url = f"{base_url}/sessions/{session_id}/models/{filename}"
     return file_path, model_url
 
-def call_hunyuan_shape_generation_api(image_filepath: str, caption: str = None):
+def call_hunyuan_shape_generation_api(image_filepaths, caption):
     try:
         client = get_hunyuan_client()
 
-        result = client.predict(
-            caption=caption,
-            image=handle_file(image_filepath),
-            steps=5,
-            guidance_scale=5,
-            seed=1234,
-            octree_resolution=256,
-            check_box_rembg=True,
-            num_chunks=8000,
-            randomize_seed=False,
-            api_name=hunyuan_api_name
-        )
+        predict_args = {
+            "caption": caption,
+            "image": None,
+            "mv_image_front": None,
+            "mv_image_back": None,
+            "mv_image_left": None,
+            "mv_image_right": None,
+            "api_name": hunyuan_api_name
+        }
+
+        if len(image_filepaths) == 1:
+            print(f"INFO: Passing single image '{os.path.basename(image_filepaths["front"])}' to 'image' argument")
+            predict_args["image"] = handle_file(image_filepaths["front"])
+        elif len(image_filepaths) > 1:
+            print(f"INFO: Passing {len(image_filepaths)} images to multi-view arguments")
+            predict_args["image"] = handle_file(image_filepaths["front"])
+
+            if "front" in image_filepaths:
+                predict_args["mv_image_front"] = handle_file(image_filepaths["front"])
+            if "back" in image_filepaths:
+                predict_args["mv_image_back"] = handle_file(image_filepaths["back"])
+            if "left" in image_filepaths:
+                predict_args["mv_image_left"] = handle_file(image_filepaths["left"])
+            if "right" in image_filepaths:
+                predict_args["mv_image_right"] = handle_file(image_filepaths["right"])
+        else:
+            raise ValueError("No image file paths provided to Hunyuan API call")
+        
+        result = client.predict(**predict_args)
 
         generated_model_filepath = result[0]["value"]
         


### PR DESCRIPTION
- Add /sessions to gitignore
- Edit process image endpoint to accept front, back, left, right images and caption (text prompt)
- Add helper function for saving images to directory with a key / value
- Edit call_hunyuan_shape_generation_api to utilise the multi view images

This results in a more accurate 3D model generation